### PR TITLE
custom query support

### DIFF
--- a/duneanalytics/duneanalytics.py
+++ b/duneanalytics/duneanalytics.py
@@ -84,14 +84,21 @@ class DuneAnalytics:
         else:
             print(response.text)
 
-    def query_result_id(self, query_id):
+    def query_result_id(self, query_id, parameters=[]):
         """
         Fetch the query result id for a query
 
         :param query_id: provide the query_id
+        :param parameters: (optional) list of parameter objects to customize the query
+            ex. [{"type": "data_type", "key": "key_name", "value": "value"}]
         :return:
         """
-        query_data = {"operationName": "GetResult", "variables": {"query_id": query_id},
+        if parameters:
+            query_variables = {"query_id": query_id, "parameters": parameters}
+        else:
+            query_variables = {"query_id": query_id}
+
+        query_data = {"operationName": "GetResult", "variables": query_variables,
                       "query": "query GetResult($query_id: Int!, $parameters: [Parameter!]) "
                                "{\n  get_result(query_id: $query_id, parameters: $parameters) "
                                "{\n    job_id\n    result_id\n    __typename\n  }\n}\n"


### PR DESCRIPTION
## Reference Issues/PRs
None

## What does this do
Added an optional `parameters` parameter to the `query_result_id` method

I've confirmed this backwards compatible with Dune queries 
- that have customer parameter(s) defined (ie. using default values configured in the web app) 
- that do not have custom parameters

Note that user can "shoot themselves in the foot" by supplying this `parameter` on queries that don't have any custom parameters defined

<img width="652" alt="image" src="https://user-images.githubusercontent.com/12478541/154382667-5ec15339-b780-4575-8b09-37d7444c9f44.png">

